### PR TITLE
proot: fix missing args

### DIFF
--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -187,7 +187,7 @@ func (b *SpecBuilder) applyEntrypoint() {
 		args = []string{}
 	}
 	if b.prootPath != "" {
-		args = append([]string{"/dev/proot/proot"}, args...)
+		args = append([]string{"/dev/proot/proot", "-0"}, args...)
 	}
 	b.SetProcessArgs(args)
 }


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

PRoot is not functional without `-0`.


Test: `cntnr run -it  --proot --proot-path ~/.runrootless/runrootless-proot docker://ubuntu  apt update`

@mgoltzsche                                                                                                     
